### PR TITLE
Improve logging for invalid GPT responses

### DIFF
--- a/api/mood.js
+++ b/api/mood.js
@@ -285,8 +285,9 @@ async function fetchOpenAIPool(mood, criteria) {
   let raw = resp.choices[0]?.message?.content || "[]";
   try {
     return JSON.parse(raw);
-  } catch {
-    console.error("Invalid GPT response, returning empty pool.");
+  } catch (err) {
+    const truncated = raw.length > 500 ? raw.slice(0, 500) + "..." : raw;
+    console.error("Invalid GPT response:", truncated, err);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- log the invalid GPT output (truncated) and error when JSON parsing fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688988c86fb883219ac4397d51e068f8