### PR TITLE
Improve GPT response parsing

### DIFF
--- a/api/mood.js
+++ b/api/mood.js
@@ -283,6 +283,10 @@ async function fetchOpenAIPool(mood, criteria) {
   });
 
   let raw = resp.choices[0]?.message?.content || "[]";
+  raw = raw.trim();
+  if (raw.startsWith("```")) {
+    raw = raw.replace(/^```(?:json)?\n/, "").replace(/\n```$/, "");
+  }
   try {
     return JSON.parse(raw);
   } catch (err) {
@@ -320,5 +324,4 @@ async function fetchSpotifyPlaylist(query) {
   }
 }
 
-console.log("OPENAI_API_KEY in runtime:", process.env.OPENAI_API_KEY);
 


### PR DESCRIPTION
## Summary
- trim code block wrappers when parsing GPT responses
- remove console log leaking OPENAI_API_KEY

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688987b2abac83219536ba4fe33a0438